### PR TITLE
Added typedef to NS_NUM to avoid 'Duplicate Symbol _ReadyState'

### DIFF
--- a/XMLHTTPRequest/XMLHTTPRequest.h
+++ b/XMLHTTPRequest/XMLHTTPRequest.h
@@ -3,7 +3,7 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 
 
-NS_ENUM(NSUInteger , ReadyState) {
+typedef NS_ENUM(NSUInteger , ReadyState) {
     XMLHttpRequestUNSENT =0,	// open()has not been called yet.
     XMLHTTPRequestOPENED,	    // send()has not been called yet.
     XMLHTTPRequestHEADERS,      // RECEIVED	send() has been called, and headers and status are available.


### PR DESCRIPTION
Hi,

In one of our internal projects (Enterprise App), including this library caused the following errors:

duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/iRepEntityCollectionViewController.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/CPDEntityViewController.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/e2Field.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/MutableQTECellView.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/ProductQuoteWithLeftAccessoryTableViewCell.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/EntityCollectionViewController.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteDocumentsTableViewController.o
duplicate symbol _ReadyState in:
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/QuoteCustomerViewController.o
    /Users/pjr/Library/Developer/Xcode/DerivedData/iRep-dwroyhlttiubnqgwrzdnriisbuuc/Build/Intermediates/iRep.build/Debug-iphonesimulator/iRep.build/Objects-normal/x86_64/XMLHTTPRequest.o
ld: 8 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Adding typedef in front of the ReadState NS_ENUM definition resolved the error.  Interestingly we also use the project in another internal app and didn't have the issue, so I'm guessing there's some Xcode build setting difference between them.

Thanks
Peter
